### PR TITLE
Fixed missing @Serializable on DTOs and shadowJar build dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,6 +75,12 @@ dependencies {
     testImplementation(libs.ktor.client.mock)
 }
 
+val shadowJarTask = tasks.named("shadowJar")
+tasks.named("distZip") { dependsOn(shadowJarTask) }
+tasks.named("distTar") { dependsOn(shadowJarTask) }
+tasks.named("startScripts") { dependsOn(shadowJarTask) }
+tasks.named("startShadowScripts") { dependsOn(tasks.named("jar")) }
+
 ktor {
     fatJar {
         archiveFileName.set("${rootProject.name}-${rootProject.version}.jar")

--- a/src/main/kotlin/es/wokis/data/dto/sound/SoundDTO.kt
+++ b/src/main/kotlin/es/wokis/data/dto/sound/SoundDTO.kt
@@ -3,7 +3,9 @@ package es.wokis.data.dto.sound
 import es.wokis.data.dto.user.UserDTO
 import es.wokis.utils.HashGenerator.generateHashWithSeed
 import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class SoundDTO(
     @SerialName("id")
     val id: Long? = null,
@@ -25,6 +27,7 @@ data class SoundDTO(
     val reactions: List<ReactionDTO>
 )
 
+@Serializable
 data class ReactionDTO(
     @SerialName("unicode")
     val unicode: String,
@@ -32,6 +35,7 @@ data class ReactionDTO(
     val addedBy: String
 )
 
+@Serializable
 data class SoundRequestDTO(
     @SerialName("title")
     val title: String,

--- a/src/main/kotlin/es/wokis/data/dto/stats/StatsDTO.kt
+++ b/src/main/kotlin/es/wokis/data/dto/stats/StatsDTO.kt
@@ -2,7 +2,9 @@ package es.wokis.data.dto.stats
 
 import es.wokis.data.bo.StatsType
 import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class StatsDTO(
     @SerialName("type")
     val type: StatsType,
@@ -10,6 +12,7 @@ data class StatsDTO(
     val stats: List<StatDTO>
 )
 
+@Serializable
 data class StatDTO(
     @SerialName("description")
     val description: String?,

--- a/src/main/kotlin/es/wokis/data/dto/totp/TOTPResponseDTO.kt
+++ b/src/main/kotlin/es/wokis/data/dto/totp/TOTPResponseDTO.kt
@@ -1,7 +1,9 @@
 package es.wokis.data.dto.totp
 
 import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class TOTPResponseDTO(
     @SerialName("encodedSecret")
     val encodedSecret: String,

--- a/src/main/kotlin/es/wokis/data/dto/user/UserDTO.kt
+++ b/src/main/kotlin/es/wokis/data/dto/user/UserDTO.kt
@@ -2,7 +2,9 @@ package es.wokis.data.dto.user
 
 import es.wokis.data.constants.ServerConstants.EMPTY_TEXT
 import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class UserDTO(
     @SerialName("id")
     val id: String,

--- a/src/main/kotlin/es/wokis/data/dto/user/auth/Auth.kt
+++ b/src/main/kotlin/es/wokis/data/dto/user/auth/Auth.kt
@@ -3,7 +3,9 @@ package es.wokis.data.dto.user.auth
 import es.wokis.data.constants.ServerConstants.DEFAULT_LANG
 import es.wokis.services.GOOGLE_AUTHENTICATOR
 import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class LoginDTO(
     @SerialName("username")
     val username: String,
@@ -12,6 +14,7 @@ data class LoginDTO(
     val isGoogleAuth: Boolean = false
 )
 
+@Serializable
 data class RegisterDTO(
     @SerialName("username")
     val username: String,
@@ -24,16 +27,19 @@ data class RegisterDTO(
     val isGoogleAuth: Boolean = false
 )
 
+@Serializable
 data class AuthResponseDTO(
     @SerialName("authToken")
     val authToken: String
 )
 
+@Serializable
 data class GoogleAuthDTO(
     @SerialName("authToken")
     val authToken: String
 )
 
+@Serializable
 data class ChangePassRequestDTO(
     @SerialName("oldPass")
     val oldPass: String?,
@@ -43,6 +49,7 @@ data class ChangePassRequestDTO(
     val newPass: String
 )
 
+@Serializable
 data class TOTPRequestDTO(
     @SerialName("authType")
     val authType: String = GOOGLE_AUTHENTICATOR,

--- a/src/main/kotlin/es/wokis/data/dto/user/update/UpdateUserDTO.kt
+++ b/src/main/kotlin/es/wokis/data/dto/user/update/UpdateUserDTO.kt
@@ -1,7 +1,9 @@
 package es.wokis.data.dto.user.update
 
 import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class UpdateUserDTO(
     @SerialName("username")
     val username: String?,


### PR DESCRIPTION
Solves #8

**Changelist Summary**
Added `@Serializable` to all DTOs missing the annotation and fixed a pre-existing `shadowJar` build task dependency issue.

**Description**
- Added `@Serializable` + import to 14 data classes across 6 DTO files: `LoginDTO`, `RegisterDTO`, `AuthResponseDTO`, `GoogleAuthDTO`, `ChangePassRequestDTO`, `TOTPRequestDTO`, `StatsDTO`, `StatDTO`, `SoundDTO`, `ReactionDTO`, `SoundRequestDTO`, `TOTPResponseDTO`, `UserDTO`, `UpdateUserDTO`
- Fixed `shadowJar` Gradle validation errors by declaring explicit task dependencies between `distZip`/`distTar`/`startScripts`/`startShadowScripts` and `shadowJar`/`jar`

**Steps to reproduce**
1. Send `POST /login` with `{username, password}` JSON
2. Server returns `400 Bad Request` with serialization error in logs
3. After fix, login deserializes correctly