### PR TITLE
Fixed circular dependency between shadowJar and dist tasks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,10 +89,6 @@ ktor {
     }
 }
 
-tasks.shadowJar {
-    dependsOn.addAll(listOf("compileJava", "compileKotlin", "processResources", "distTar", "distZip"))
-}
-
 tasks.test {
     useJUnitPlatform()
     finalizedBy(tasks.jacocoTestReport) // report is always generated after tests run


### PR DESCRIPTION
Solves the circular dependency introduced when merging #5 into master.

**Changelist Summary**
Removed the old `tasks.shadowJar { dependsOn.addAll("distTar", "distZip") }` block that created a circular dependency with the correct `distTar/distZip → shadowJar` fix already on master.

**Description**
PR #5 added `shadowJar → distTar/distZip` deps (wrong direction). PR #9 added `distTar/distZip → shadowJar` deps (correct direction). After merging both into master, both ended up in `build.gradle.kts`, creating:

```
distTar → shadowJar → distTar (CIRCLE!)
```

This removes the old wrong-direction block, keeping only the correct deps.